### PR TITLE
fix: correct digest array examples

### DIFF
--- a/examples/cert-val.diag
+++ b/examples/cert-val.diag
@@ -19,9 +19,11 @@
             / comid.mkey / 0 : "psa.software-component",
             / comid.mval / 1 : {
               / comid.digests / 2 : [
-                / hash-alg-id / "sha-256",
-                / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
+                [
+                  / hash-alg-id / "sha-256",
+                  / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
                                   fad053beb8ebfd8977b010655bfdd3c3'
+                ]
               ],
               / name / 11 : "PRoT",
               / cryptokeys / 13 : [ 560(h'5378796307535df3ec8d8b15a2

--- a/examples/ref-value.diag
+++ b/examples/ref-value.diag
@@ -19,9 +19,11 @@
             / comid.mkey / 0 : "psa.software-component",
             / comid.mval / 1 : {
               / comid.digests / 2 : [
-                / hash-alg-id / "sha-256",
-                / hash-value /  h'9a271f2a916b0b6ee6cecb2426f0b320
+                [
+                  / hash-alg-id / "sha-256",
+                  / hash-value /  h'9a271f2a916b0b6ee6cecb2426f0b320
                                   6ef074578be55d9bc94f6f3fe3ab86aa'
+                ]
               ],
               / name / 11 : "BL",
               / cryptokeys / 13 : [ 560(h'5378796307535df3ec8d8b15a2
@@ -33,9 +35,11 @@
             / comid.mkey / 0 : "psa.software-component",
             / comid.mval / 1 : {
               / comid.digests / 2 : [
-                / hash-alg-id / "sha-256",
-                / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
+                [
+                  / hash-alg-id / "sha-256",
+                  / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
                                   fad053beb8ebfd8977b010655bfdd3c3'
+                ]
               ],
               / name / 11 : "PRoT",
               / cryptokeys / 13 : [ 560(h'5378796307535df3ec8d8b15a2

--- a/examples/swrel-update-crit.diag
+++ b/examples/swrel-update-crit.diag
@@ -20,9 +20,11 @@
               / comid.version / 0 : "1.3.0",
             },
               / comid.digests / 2 : [
-                / hash-alg-id / "sha-256",
-                / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
+                [
+                  / hash-alg-id / "sha-256",
+                  / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
                                   fad053beb8ebfd8977b010655bfdd3c3'
+                ]
               ],
               / name / 11 : "PRoT",
               / cryptokeys / 13 : [ 560(h'5378796307535df3ec8d8b15a2
@@ -41,9 +43,11 @@
                   / comid.version / 0 : "1.2.5",
                 },
               / comid.digests / 2 : [
-                / hash-alg-id / "sha-256",
-                / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
+                [
+                  / hash-alg-id / "sha-256",
+                  / hash-value /  h'53c234e5e8472b6ac51c1ae1cab3fe06
                                   fad053beb8ebfd8978b010655bfdd3c3'
+                ]
               ],
               / name / 11 : "PRoT",
               / cryptokeys / 13 : [ 560(h'5378796307535df3ec8d8b15a2


### PR DESCRIPTION
Fixes #10

This updates the example DIAG files so `comid.digests` is encoded as an array of `eatmc.digest` entries, matching the CDDL in the draft.

Testing: ran `git diff --check`.